### PR TITLE
add support for es6 classed models in Backendless.DataStore

### DIFF
--- a/libs/backendless.js
+++ b/libs/backendless.js
@@ -391,6 +391,10 @@
         if (this.prototype && this.prototype.___class)
             return this.prototype.___class;
 
+        if (Utils.isFunction(this) && this.name) {
+            return this.name;
+        }
+
         var instStringified = (Utils.isFunction(this) ? this.toString() : this.constructor.toString()),
             results         = instStringified.match(/function\s+(\w+)/);
         return (results && results.length > 1) ? results[1] : '';


### PR DESCRIPTION
It makes possible to use es6 `classes` with `Backendless.Persistence` :

```
class Person {
}

Backendless.Persistence.of(Person)
```