### PR TITLE
Fix DataStore find results traversing

### DIFF
--- a/libs/backendless.js
+++ b/libs/backendless.js
@@ -465,7 +465,7 @@
     };
 
     function extendCollection(collection, dataMapper) {
-        if (collection.nextPage !== undefined) {
+        if (collection.nextPage != null) {
             if (collection.nextPage && collection.nextPage.split("/")[1] == Backendless.appVersion) {
                 collection.nextPage = Backendless.serverURL + collection.nextPage;
             }


### PR DESCRIPTION
Bug fixes:
* `DataStore.find` method always prepares `response.nextPage` method even if the next page doesn't exist
