### PR TITLE
assignRole response value must be void

### DIFF
--- a/libs/backendless.d.ts
+++ b/libs/backendless.d.ts
@@ -773,11 +773,11 @@ declare module __Backendless {
         restorePassword(email:string):Backendless.User ;
         restorePassword(email:string, async:Backendless.Async):XMLHttpRequest;
 
-        assignRole(userName:string, roleName:string):Backendless.User ;
-        assignRole(userName:string, roleName:string, async:Backendless.Async):XMLHttpRequest;
+        assignRole(identity:string, roleName:string):Backendless.User ;
+        assignRole(identity:string, roleName:string, async:Backendless.Async):XMLHttpRequest;
 
-        unassignRole(userName:string, roleName:string):Backendless.User ;
-        unassignRole(userName:string, roleName:string, async:Backendless.Async):XMLHttpRequest;
+        unassignRole(identity:string, roleName:string):Backendless.User ;
+        unassignRole(identity:string, roleName:string, async:Backendless.Async):XMLHttpRequest;
 
         login(userName:string, password:string):Backendless.User ;
         login(userName:string, password:string, stayLoggedIn:boolean):Backendless.User ;

--- a/tests/tsd.ts
+++ b/tests/tsd.ts
@@ -303,6 +303,7 @@ function testUser() {
 
 function testUserService() {
     var userName:string = 'userName';
+    var identity:string = 'identity';
     var roleName:string = 'rolename';
     var password:string = 'password';
     var div:HTMLElement = document.createElement('div');
@@ -326,11 +327,11 @@ function testUserService() {
     newUser = Backendless.UserService.getUserRoles();
     resultXHR = Backendless.UserService.getUserRoles(async);
 
-    newUser = Backendless.UserService.assignRole(userName, roleName);
-    resultXHR = Backendless.UserService.assignRole(userName, roleName, async);
+    newUser = Backendless.UserService.assignRole(identity, roleName);
+    resultXHR = Backendless.UserService.assignRole(identity, roleName, async);
 
-    newUser = Backendless.UserService.unassignRole(userName, roleName);
-    resultXHR = Backendless.UserService.unassignRole(userName, roleName, async);
+    newUser = Backendless.UserService.unassignRole(identity, roleName);
+    resultXHR = Backendless.UserService.unassignRole(identity, roleName, async);
 
     newUser = Backendless.UserService.login(userName, password);
     newUser = Backendless.UserService.login(userName, password, bol);


### PR DESCRIPTION
- fix (**ajax**) empty string in async callback if server response has no body in node env. Must be undefined
- fix (**users**) `assignRole` and `unassignRole` must be `void` in async mode
- refactor (**users**) rename `username` argument name to `identity` for `assignRole` and `unassignRole` methods