### PR TITLE
Change LocalStorage Emptiness identification

### DIFF
--- a/libs/backendless.js
+++ b/libs/backendless.js
@@ -656,7 +656,7 @@
             storage = window[localStorageName];
 
             var createBndlsStorage = function() {
-                if (!('Backendless' in storage)) {
+                if (!(storage.getItem('Backendless'))) {
                     storage.setItem('Backendless', store.serialize({}));
                 }
             };
@@ -2083,7 +2083,7 @@
                 asyncHandler: responder
             });
         },
-      
+
         /** @deprecated */
         addPoint: function(geopoint, async) {
           return this.savePoint.apply(this, arguments);


### PR DESCRIPTION
Throughout the SDK, the standard `setItem` `getItem` from the localStorage spec are used.
Line 659 is the only one that uses the assumption that localStorage inherits all of `Object`s behaviours:
```javascript
if (!('Backendless' in storage)) {
```
While this works in browsers, this could potentially create issues with various environments that use Polyfills for localStorage such as Tabris.js  (I would assume also React Native, Nativescript).

A simple solution to this issue is using the standard `getItem` api.
```javascript
if (!(storage.getItem('Backendless'))) {
```

You can see how this issue creates issue in Tabris.js: https://github.com/eclipsesource/tabris-js/issues/892 where effectively the cache is wiped up constantly.