### PR TITLE
Fix file uploading for IE

### DIFF
--- a/libs/backendless.js
+++ b/libs/backendless.js
@@ -3618,7 +3618,7 @@
                             reader.onerror = function(evn) {
                                 async.fault(evn);
                             };
-                            reader.readAsBinaryString(files[i]);
+                            reader.readAsArrayBuffer(files[i]);
 
                         } catch (err) {
                             filesError++;


### PR DESCRIPTION
IE does not support readAsBinaryString method of FileReader instance. Changing it to readAsArrayBuffer should resolve this issue for all modern browsers.