### PR TITLE
fix - parse getObjectCount method response and add it to type definitions

### DIFF
--- a/libs/backendless.d.ts
+++ b/libs/backendless.d.ts
@@ -429,6 +429,9 @@ declare module __Backendless {
         bulkDelete(objectsArray:string|Array<string>|Array<Object>):Promise<string>;
         bulkDeleteSync(objectsArray:string|Array<string>|Array<Object>):string;
 
+        getObjectCount(whereClause?:string):Promise<number>;
+        getObjectCountSync(whereClause?:string):number;
+
     }
 
     /**

--- a/libs/backendless.js
+++ b/libs/backendless.js
@@ -1417,6 +1417,7 @@
       var dataQuery = args.queryBuilder ? args.queryBuilder.build() : {};
       var url = this.restUrl + '/count';
       var isAsync = !!args.async;
+      var asyncHandler = Utils.wrapAsync(args.async, Number, this);
 
       if (dataQuery.condition) {
         url += '?where=' + encodeURIComponent(dataQuery.condition);
@@ -1426,7 +1427,7 @@
         method      : 'GET',
         url         : url,
         isAsync     : isAsync,
-        asyncHandler: args.async
+        asyncHandler: asyncHandler
       });
     },
 


### PR DESCRIPTION
Previously `getObjectCount` method returned to client count as a string