### PR TITLE
Query builder for findById, findLast and findFirst methods and findLast methods

### DIFF
--- a/src/backendless.js
+++ b/src/backendless.js
@@ -1232,7 +1232,7 @@
       var responder = Utils.extractResponder(arguments);
 
       if (Utils.isString(arguments[0])) {
-        argsObj = arguments[1] || {};
+        argsObj = !(arguments[1] instanceof Async) ? (arguments[1] || {}) : {};
         argsObj.url = arguments[0];
 
         if (!argsObj.url) {
@@ -1348,7 +1348,7 @@
     findFirstSync: synchronized('_findFirst'),
 
     _findFirst: function() {
-      var argsObj = arguments[0] || {};
+      var argsObj = !(arguments[0] instanceof Async) ? (arguments[0] || {}) : {};
       argsObj.url = 'first';
 
       return this._findUtil.apply(this, [argsObj].concat(Array.prototype.slice.call(arguments)));
@@ -1359,7 +1359,7 @@
     findLastSync: synchronized('_findLast'),
 
     _findLast: function() {
-      var argsObj = arguments[0] || {};
+      var argsObj = !(arguments[0] instanceof Async) ? (arguments[0] || {}) : {};
       argsObj.url = 'last';
 
       return this._findUtil.apply(this, [argsObj].concat(Array.prototype.slice.call(arguments)));

--- a/src/backendless.js
+++ b/src/backendless.js
@@ -1223,37 +1223,6 @@
       return isAsync ? result : this._parseFindResponse(result);
     },
 
-    _buildArgsObject: function() {
-      var args = {},
-          i    = arguments.length,
-          type = "";
-      for (; i--;) {
-        type = Object.prototype.toString.call(arguments[i]).toLowerCase().match(/[a-z]+/g)[1];
-        switch (type) {
-          case "number":
-            args.options = args.options || {};
-            args.options.relationsDepth = arguments[i];
-            break;
-          case "string":
-            args.url = arguments[i];
-            break;
-          case "array":
-            args.options = args.options || {};
-            args.options.relations = arguments[i];
-            break;
-          case "object":
-            if (arguments[i].hasOwnProperty('cachePolicy')) {
-              args.cachePolicy = arguments[i]['cachePolicy'];
-            }
-            break;
-          default:
-            break;
-        }
-      }
-
-      return args;
-    },
-
     findById: promisified('_findById'),
 
     findByIdSync: synchronized('_findById'),
@@ -1262,12 +1231,14 @@
       var argsObj;
 
       if (Utils.isString(arguments[0])) {
-        argsObj = this._buildArgsObject.apply(this, arguments);
-        if (!(argsObj.url)) {
+        argsObj = arguments[1] || {}
+        argsObj.url = arguments[0]
+
+        if (!argsObj.url) {
           throw new Error('missing argument "object ID" for method findById()');
         }
 
-        return this._findUtil.apply(this, [argsObj].concat(Array.prototype.slice.call(arguments)));
+        return this._findUtil(argsObj);
       } else if (Utils.isObject(arguments[0])) {
         argsObj = arguments[0];
         var responder = Utils.extractResponder(arguments),
@@ -1377,7 +1348,7 @@
     findFirstSync: synchronized('_findFirst'),
 
     _findFirst: function() {
-      var argsObj = this._buildArgsObject.apply(this, arguments);
+      var argsObj = arguments[0] || {};
       argsObj.url = 'first';
 
       return this._findUtil.apply(this, [argsObj].concat(Array.prototype.slice.call(arguments)));
@@ -1388,7 +1359,7 @@
     findLastSync: synchronized('_findLast'),
 
     _findLast: function() {
-      var argsObj = this._buildArgsObject.apply(this, arguments);
+      var argsObj = arguments[0] || {};
       argsObj.url = 'last';
 
       return this._findUtil.apply(this, [argsObj].concat(Array.prototype.slice.call(arguments)));

--- a/src/backendless.js
+++ b/src/backendless.js
@@ -1229,20 +1229,20 @@
 
     _findById: function() {
       var argsObj;
+      var responder = Utils.extractResponder(arguments);
 
       if (Utils.isString(arguments[0])) {
-        argsObj = arguments[1] || {}
-        argsObj.url = arguments[0]
+        argsObj = arguments[1] || {};
+        argsObj.url = arguments[0];
 
         if (!argsObj.url) {
           throw new Error('missing argument "object ID" for method findById()');
         }
 
-        return this._findUtil(argsObj);
+        return this._findUtil(argsObj, responder);
       } else if (Utils.isObject(arguments[0])) {
         argsObj = arguments[0];
-        var responder = Utils.extractResponder(arguments),
-            url       = this.restUrl,
+        var url       = this.restUrl,
             isAsync   = responder != null,
             send      = "/pk?";
 

--- a/test/e2e/specs/persistence.js
+++ b/test/e2e/specs/persistence.js
@@ -23,497 +23,500 @@ const users = {
   }
 }
 
-describe('Backendless.Persistence', function() {
-  describe('Persistence', function() {
-    let consoleApi
-    let appId
-    let Persistence
+describe('Persistence', function() {
+  let consoleApi
+  let appId
 
-    const insertRecord = (tableName, record) =>
-      consoleApi.tables.createRecord(appId, { name: tableName }, record)
+  let Persistence
 
-    const insertUsers = () =>
-      Promise.resolve()
-        .then(() => insertRecord('Users', users.john))
-        .then(() => insertRecord('Users', users.paul))
-        .then(() => insertRecord('Users', users.george))
+  const insertRecord = (tableName, record) =>
+    consoleApi.tables.createRecord(appId, { name: tableName }, record)
 
-    const createBigTable = () => {
-      const paginationTestData = [...Array(100).keys()].map(i => ({ counter: i + 1, name: 'John ' + (i + 1) }))
+  const insertUsers = () =>
+    Promise.resolve()
+      .then(() => insertRecord('Users', users.john))
+      .then(() => insertRecord('Users', users.paul))
+      .then(() => insertRecord('Users', users.george))
 
-      return Promise.resolve()
-        .then(() => insertRecord('TableWithPagination', { counter: 0, name: 'Initial' }))
-        .then(() => Promise.all(paginationTestData.map(record => insertRecord('TableWithPagination', record))))
+  const createBigTable = () => {
+    const paginationTestData = [...Array(100).keys()].map(i => ({ counter: i + 1, name: 'John ' + (i + 1) }))
+
+    return Promise.resolve()
+      .then(() => insertRecord('TableWithPagination', { counter: 0, name: 'Initial' }))
+      .then(() => Promise.all(paginationTestData.map(record => insertRecord('TableWithPagination', record))))
+  }
+
+  sandbox.forTest()
+
+  beforeEach(function() {
+    consoleApi = this.consoleApi
+    appId = this.app.id
+    Persistence = Backendless.Persistence
+  })
+
+  it('Create new table', function() {
+    const entity = new Foo()
+    entity.firstName = 'First'
+    entity.lastName = 'Last'
+
+    return Persistence.of(Foo).save(entity).then(result => {
+      expect(result).to.be.instanceof(Foo)
+      expect(result.objectId).to.be.a('string')
+      expect(result.firstName).to.be.equal(entity.firstName)
+      expect(result.lastName).to.be.equal(entity.lastName)
+    })
+  })
+
+  it('Update record', function() {
+    const entity = new Foo()
+    entity.firstName = 'Bill'
+    entity.lastName = 'Gates'
+
+    const db = Persistence.of(Foo)
+
+    return db.save(entity)
+      .then(() => entity.firstName = 'Ron')
+      .then(() => db.save(entity))
+      .then(updated => {
+        expect(updated.firstName).to.be.equal(entity.firstName)
+        expect(updated.lastName).to.be.equal(entity.lastName)
+      })
+  })
+
+  it('Remove record', function() {
+    const db = Persistence.of('TableToTestDeletion')
+    let toRemove
+
+    return Promise.resolve()
+      .then(() => insertRecord('TableToTestDeletion', { evil: 'Justin Bieber' })) // let destroy the evil
+      .then(() => db.findFirst())
+      .then(result => {
+        toRemove = result
+
+        return db.remove(result.objectId)
+      })
+      .then(() => db.findById(toRemove.objectId))
+      .catch(error => {
+        expect(error.message).to.be.equal(`Entity with name ${toRemove.objectId} cannot be found`)
+      })
+      .then(() => db.find())
+      .then(result => {
+        expect(result.length).to.be.equal(0) // the world is saved
+      })
+  })
+
+  it('Add record to Users table', function() {
+    const db = Persistence.of(Backendless.User)
+
+    const user = {
+      email   : 'ringo@starr.co',
+      name    : 'Ringo Starr',
+      password: 'beatlesforever'
     }
 
-    sandbox.forTest()
-
-    beforeEach(function() {
-      consoleApi = this.consoleApi
-      appId = this.app.id
-      Persistence = Backendless.Persistence
-    })
-
-    it('Create new table', function() {
-      const entity = new Foo()
-      entity.firstName = 'First'
-      entity.lastName = 'Last'
-
-      return Persistence.of(Foo).save(entity).then(result => {
-        expect(result).to.be.instanceof(Foo)
-        expect(result.objectId).to.be.a('string')
-        expect(result.firstName).to.be.equal(entity.firstName)
-        expect(result.lastName).to.be.equal(entity.lastName)
+    return Promise.resolve()
+      .then(insertUsers)
+      .then(() => db.save(user))
+      .then(result => {
+        expect(result).to.be.an.instanceof(Backendless.User)
+        expect(result).to.have.property('email').that.equal(user.email)
+        expect(result).to.have.property('name').that.equal(user.name)
+        expect(result).to.not.have.property('password')
       })
-    })
+  })
 
-    it('Update record', function() {
-      const entity = new Foo()
-      entity.firstName = 'Bill'
-      entity.lastName = 'Gates'
+  it('Impossible to get persistence of Users using string signature', function() {
+    const db = () => Persistence.of('Users')
 
-      const db = Persistence.of(Foo)
+    const expectedError = "Table 'Users' is not accessible through this signature. " +
+      "Use Backendless.Data.of( Backendless.User ) instead"
 
-      return db.save(entity)
-        .then(() => entity.firstName = 'Ron')
-        .then(() => db.save(entity))
-        .then(updated => {
-          expect(updated.firstName).to.be.equal(entity.firstName)
-          expect(updated.lastName).to.be.equal(entity.lastName)
-        })
-    })
+    expect(db).to.throw(expectedError)
+  })
 
-    it('Remove record', function() {
-      const db = Persistence.of('TableToTestDeletion')
-      let toRemove
+  it('Check instance of objects from Users table', function() {
+    const db = Persistence.of(Backendless.User)
 
-      return Promise.resolve()
-        .then(() => insertRecord('TableToTestDeletion', { evil: 'Justin Bieber' })) // let destroy the evil
-        .then(() => db.findFirst())
-        .then(result => {
-          toRemove = result
+    return Promise.resolve()
+      .then(insertUsers)
+      .then(() => db.find())
+      .then(result => {
+        result.forEach(object => expect(object).to.be.an.instanceof(Backendless.User))
+      })
+  })
 
-          return db.remove(result.objectId)
-        })
-        .then(() => db.findById(toRemove.objectId))
-        .catch(error => {
-          expect(error.message).to.be.equal(`Entity with name ${toRemove.objectId} cannot be found`)
-        })
-        .then(() => db.find())
-        .then(result => {
-          expect(result.length).to.be.equal(0) // the world is saved
-        })
-    })
+  it('Update table record with invalid data type for properties', function() {
+    const db = Persistence.of('Blackstar')
 
-    it('Add record to Users table', function() {
-      const db = Persistence.of(Backendless.User)
+    return Promise.resolve()
+      .then(() => insertRecord('Blackstar', { integerCol: 1, boolCol: false }))
+      .then(() => db.findFirst())
+      .then(result => {
+        result.integerCol = 'String value' // column type is Number
+        result.boolCol = 'String value' // column type is Boolean
 
-      const user = {
-        email   : 'ringo@starr.co',
-        name    : 'Ringo Starr',
-        password: 'beatlesforever'
-      }
+        return result
+      })
+      .then(result => db.save(result))
+      .catch(error => {
+        expect(error.message).to.match(/Unable to save object - invalid data type for properties/)
+      })
+  })
 
-      return Promise.resolve()
-        .then(insertUsers)
-        .then(() => db.save(user))
-        .then(result => {
-          expect(result).to.be.an.instanceof(Backendless.User)
-          expect(result).to.have.property('email').that.equal(user.email)
-          expect(result).to.have.property('name').that.equal(user.name)
-          expect(result).to.not.have.property('password')
-        })
-    })
+  it('Remove object with wrong type of objectId', function() {
+    const db = Persistence.of('Blackstar')
+    const expectedError = 'Invalid value for the "value" argument. ' +
+      'The argument must contain only string or object values'
 
-    it('Impossible to get persistence of Users using string signature', function() {
-      const db = () => Persistence.of('Users')
+    return Promise.resolve()
+      .then(() => insertRecord('Blackstar', { integerCol: 1, boolCol: false }))
+      .then(() => db.remove(9999)) // remove expect only string parameter
+      .catch(error => expect(error.message).to.be.equal(expectedError))
+  })
 
-      const expectedError = "Table 'Users' is not accessible through this signature. " +
-        "Use Backendless.Data.of( Backendless.User ) instead"
+  it('Save object with Backendless.Persistence.save() notation', function() {
+    const record = {
+      name : 'David',
+      email: 'david@bowie.co.ua'
+    }
 
-      expect(db).to.throw(expectedError)
-    })
+    return Promise.resolve()
+      .then(() => insertRecord('Blackstar', { integerCol: 1, boolCol: false }))
+      .then(() => Persistence.save('Blackstar', record))
+      .then(result => {
+        expect(result.name).to.be.equal(record.name)
+        expect(result.email).to.be.equal(record.email)
+        expect(result.___class).to.be.equal('Blackstar')
+      })
+  })
 
-    it('Check instance of objects from Users table', function() {
-      const db = Persistence.of(Backendless.User)
+  it('Save object with boolean property', function() {
+    const db = Persistence.of('Blackstar')
+    const record = {
+      boolCol: true
+    }
 
-      return Promise.resolve()
-        .then(insertUsers)
-        .then(() => db.find())
-        .then(result => {
-          result.forEach(object => expect(object).to.be.an.instanceof(Backendless.User))
-        })
-    })
+    return Promise.resolve()
+      .then(() => insertRecord('Blackstar', { integerCol: 1, boolCol: false }))
+      .then(() => db.save(record))
+      .then(result => {
+        expect(result.boolCol).to.be.a('boolean')
+        expect(result.boolCol).to.be.true
+      })
+  })
 
-    it('Update table record with invalid data type for properties', function() {
-      const db = Persistence.of('Blackstar')
+  it('Save object with int property', function() {
+    const db = Persistence.of('Blackstar')
+    const record = {
+      integerCol: 42
+    }
 
-      return Promise.resolve()
-        .then(() => insertRecord('Blackstar', { integerCol: 1, boolCol: false }))
-        .then(() => db.findFirst())
-        .then(result => {
-          result.integerCol = 'String value' // column type is Number
-          result.boolCol = 'String value' // column type is Boolean
+    return Promise.resolve()
+      .then(() => insertRecord('Blackstar', { integerCol: 1, boolCol: false }))
+      .then(() => db.save(record))
+      .then(result => {
+        expect(result.integerCol).to.be.a('number')
+        expect(result.integerCol).to.be.equal(record.integerCol)
+      })
+  })
 
-          return result
-        })
-        .then(result => db.save(result))
-        .catch(error => {
-          expect(error.message).to.match(/Unable to save object - invalid data type for properties/)
-        })
-    })
+  it('Save object with double property', function() {
+    const db = Persistence.of('Blackstar')
+    const record = {
+      doubleCol: Math.random() * 10
+    }
 
-    it('Remove object with wrong type of objectId', function() {
-      const db = Persistence.of('Blackstar')
-      const expectedError = 'Invalid value for the "value" argument. ' +
-        'The argument must contain only string or object values'
+    return Promise.resolve()
+      .then(() => insertRecord('Blackstar', { integerCol: 1, boolCol: false }))
+      .then(() => db.save(record))
+      .then(result => {
+        expect(result.doubleCol).to.be.a('number')
+        expect(result.doubleCol).to.be.equal(record.doubleCol)
+      })
+  })
 
-      return Promise.resolve()
-        .then(() => insertRecord('Blackstar', { integerCol: 1, boolCol: false }))
-        .then(() => db.remove(9999)) // remove expect only string parameter
-        .catch(error => expect(error.message).to.be.equal(expectedError))
-    })
+  it('Save object with String property', function() {
+    const db = Persistence.of('Blackstar')
+    const record = {
+      stringCol: 'string value'
+    }
 
-    it('Save object with Backendless.Persistence.save() notation', function() {
-      const record = {
-        name : 'David',
-        email: 'david@bowie.co.ua'
-      }
+    return Promise.resolve()
+      .then(() => insertRecord('Blackstar', { integerCol: 1, boolCol: false }))
+      .then(() => db.save(record))
+      .then(result => {
+        expect(result.stringCol).to.be.a('string')
+        expect(result.stringCol).to.be.equal(record.stringCol)
+      })
+  })
 
-      return Promise.resolve()
-        .then(() => insertRecord('Blackstar', { integerCol: 1, boolCol: false }))
-        .then(() => Persistence.save('Blackstar', record))
-        .then(result => {
-          expect(result.name).to.be.equal(record.name)
-          expect(result.email).to.be.equal(record.email)
-          expect(result.___class).to.be.equal('Blackstar')
-        })
-    })
+  it('Find Record By objectId', function() {
+    let entity = new Foo()
+    entity.firstName = 'Bill'
+    entity.lastName = 'Gates'
 
-    it('Save object with boolean property', function() {
-      const db = Persistence.of('Blackstar')
-      const record = {
-        boolCol: true
-      }
+    const db = Persistence.of(Foo)
 
-      return Promise.resolve()
-        .then(() => insertRecord('Blackstar', { integerCol: 1, boolCol: false }))
-        .then(() => db.save(record))
-        .then(result => {
-          expect(result.boolCol).to.be.a('boolean')
-          expect(result.boolCol).to.be.true
-        })
-    })
+    return db.save(entity)
+      .then(result => entity = result)
+      .then(() => db.findById(entity.objectId))
+      .then(serverEntity => {
+        expect(serverEntity.objectId).to.be.equal(entity.objectId)
+        expect(serverEntity.firstName).to.be.equal(entity.firstName)
+        expect(serverEntity.lastName).to.be.equal(entity.lastName)
+      })
+  })
 
-    it('Save object with int property', function() {
-      const db = Persistence.of('Blackstar')
-      const record = {
-        integerCol: 42
-      }
+  it('Find Record By Non Existing objectId', function() {
+    const db = Persistence.of('Blackstar')
 
-      return Promise.resolve()
-        .then(() => insertRecord('Blackstar', { integerCol: 1, boolCol: false }))
-        .then(() => db.save(record))
-        .then(result => {
-          expect(result.integerCol).to.be.a('number')
-          expect(result.integerCol).to.be.equal(record.integerCol)
-        })
-    })
+    return Promise.resolve()
+      .then(() => insertRecord('Blackstar', { integerCol: 1, boolCol: false }))
+      .then(() => db.findById('NonExistingObjectId'))
+      .catch(error => {
+        expect(error.message).to.be.equal('Entity with name NonExistingObjectId cannot be found')
+      })
+  })
 
-    it('Save object with double property', function() {
-      const db = Persistence.of('Blackstar')
-      const record = {
-        doubleCol: Math.random() * 10
-      }
+  it('Find with Where clause', function() {
+    const db = Persistence.of(Backendless.User)
+    const query = Backendless.DataQueryBuilder.create().setWhereClause('name like \'%Lennon%\'')
 
-      return Promise.resolve()
-        .then(() => insertRecord('Blackstar', { integerCol: 1, boolCol: false }))
-        .then(() => db.save(record))
-        .then(result => {
-          expect(result.doubleCol).to.be.a('number')
-          expect(result.doubleCol).to.be.equal(record.doubleCol)
-        })
-    })
+    return Promise.resolve()
+      .then(insertUsers)
+      .then(() => db.find(query))
+      .then(result => {
+        expect(result.length).to.be.equal(1)
+        expect(result[0].name).to.match(/Lennon/)
+      })
+  })
 
-    it('Save object with String property', function() {
-      const db = Persistence.of('Blackstar')
-      const record = {
-        stringCol: 'string value'
-      }
+  it('Find with properties', function() {
+    const db = Persistence.of('TableWithPagination')
+    const query = Backendless.DataQueryBuilder.create().setProperties(['name'])
 
-      return Promise.resolve()
-        .then(() => insertRecord('Blackstar', { integerCol: 1, boolCol: false }))
-        .then(() => db.save(record))
-        .then(result => {
-          expect(result.stringCol).to.be.a('string')
-          expect(result.stringCol).to.be.equal(record.stringCol)
-        })
-    })
+    return Promise.resolve()
+      .then(createBigTable)
+      .then(() => db.find(query))
+      .then(result => {
+        expect(result[0]).to.not.have.property('counter')
+        expect(result[0]).to.have.property('name')
+      })
+  })
 
-    it('Find Record By objectId', function() {
-      let entity = new Foo()
-      entity.firstName = 'Bill'
-      entity.lastName = 'Gates'
+  it('Find with non existing properties', function() {
+    const db = Persistence.of('TableWithPagination')
+    const query = Backendless.DataQueryBuilder.create().setProperties(['nonExistingProp']) //.setSortBy('counter').setPageSize(50)
 
-      const db = Persistence.of(Foo)
+    return Promise.resolve()
+      .then(createBigTable)
+      .then(() => db.find(query))
+      .catch(error => {
+        expect(error.message).to.be.equal('Unable to retrieve data. Query contains invalid object properties.')
+      })
+  })
 
-      return db.save(entity)
-        .then(result => entity = result)
-        .then(() => db.findById(entity.objectId))
-        .then(serverEntity => {
-          expect(serverEntity.objectId).to.be.equal(entity.objectId)
-          expect(serverEntity.firstName).to.be.equal(entity.firstName)
-          expect(serverEntity.lastName).to.be.equal(entity.lastName)
-        })
-    })
+  it('Find First', function() {
+    const db = Persistence.of('TestFindFirst')
 
-    it('Find Record By Non Existing objectId', function() {
-      const db = Persistence.of('Blackstar')
+    return Promise.resolve()
+      .then(() => insertRecord('TestFindFirst', { counter: 0, name: 'First' }))
+      .then(() => insertRecord('TestFindFirst', { counter: 1, name: 'Last' }))
+      .then(() => db.findFirst())
+      .then(result => {
+        expect(result.counter).to.be.equal(0)
+        expect(result.name).to.be.equal('First')
+      })
+  })
 
-      return Promise.resolve()
-        .then(() => insertRecord('Blackstar', { integerCol: 1, boolCol: false }))
-        .then(() => db.findById('NonExistingObjectId'))
-        .catch(error => {
-          expect(error.message).to.be.equal('Entity with name NonExistingObjectId cannot be found')
-        })
-    })
+  it('Find Last', function() {
+    const db = Persistence.of('TestFindLast')
 
-    it('Find with Where clause', function() {
-      const db = Persistence.of(Backendless.User)
-      const query = Backendless.DataQueryBuilder.create().setWhereClause('name like \'%Lennon%\'')
+    return Promise.resolve()
+      .then(() => insertRecord('TestFindLast', { counter: 0, name: 'First' }))
+      .then(() => insertRecord('TestFindLast', { counter: 1, name: 'Last' }))
+      .then(() => db.findLast())
+      .then(result => {
+        expect(result.counter).to.be.equal(1)
+        expect(result.name).to.be.equal('Last')
+      })
+  })
 
-      return Promise.resolve()
-        .then(insertUsers)
-        .then(() => db.find(query))
-        .then(result => {
-          expect(result.length).to.be.equal(1)
-          expect(result[0].name).to.match(/Lennon/)
-        })
-    })
+  /****************
+   *  RELATIONS   *
+   ****************/
 
-    it('Find with properties', function() {
-      const db = Persistence.of('TableWithPagination')
-      const query = Backendless.DataQueryBuilder.create().setProperties(['name'])
+  describe('Tables with relations', function() {
+    let parent
+    let child
+    let grandchild
+    let ParentTable
+    let ChildTable
 
-      return Promise.resolve()
-        .then(createBigTable)
-        .then(() => db.find(query))
-        .then(result => {
-          expect(result[0]).to.not.have.property('counter')
-          expect(result[0]).to.have.property('name')
-        })
-    })
+    const save = name => Persistence.of(name).save({})
+    const queryWithRelationDepth = depth => Backendless.DataQueryBuilder.create().setRelationsDepth(depth).build()
 
-    it('Find with non existing properties', function() {
-      const db = Persistence.of('TableWithPagination')
-      const query = Backendless.DataQueryBuilder.create().setProperties(['nonExistingProp']) //.setSortBy('counter').setPageSize(50)
-
-      return Promise.resolve()
-        .then(createBigTable)
-        .then(() => db.find(query))
-        .catch(error => {
-          expect(error.message).to.be.equal('Unable to retrieve data. Query contains invalid object properties.')
-        })
-    })
-
-    it('Find First', function() {
-      const db = Persistence.of('TestFindFirst')
-
-      return Promise.resolve()
-        .then(() => insertRecord('TestFindFirst', { counter: 0, name: 'First' }))
-        .then(() => insertRecord('TestFindFirst', { counter: 1, name: 'Last' }))
-        .then(() => db.findFirst())
-        .then(result => {
-          expect(result.counter).to.be.equal(0)
-          expect(result.name).to.be.equal('First')
-        })
-    })
-
-    it('Find Last', function() {
-      const db = Persistence.of('TestFindLast')
-
-      return Promise.resolve()
-        .then(() => insertRecord('TestFindLast', { counter: 0, name: 'First' }))
-        .then(() => insertRecord('TestFindLast', { counter: 1, name: 'Last' }))
-        .then(() => db.findLast())
-        .then(result => {
-          expect(result.counter).to.be.equal(1)
-          expect(result.name).to.be.equal('Last')
-        })
-    })
-
-    describe('Tables with relations', function() {
-      let parent
-      let child
-      let grandchild
-      let ParentTable
-      let ChildTable
-
-      const save = name => Persistence.of(name).save({})
-      const queryWithRelationDepth = depth => Backendless.DataQueryBuilder.create().setRelationsDepth(depth).build()
-
-      beforeEach(() => {
+    beforeEach(() => {
         ParentTable = Persistence.of('Parent')
         ChildTable = Persistence.of('Child')
 
-       return Promise.resolve()
-         .then(() => save('Parent').then(result => parent = result))
-         .then(() => save('Child').then(result => child = result))
-         .then(() => save('GrandChild').then(result => grandchild = result))
-         .then(() => ParentTable.addRelation(parent.objectId, 'child:Child:1', [child]))
-         .then(() => ChildTable.addRelation(child.objectId, 'grandChild:GrandChild:1', [grandchild]))
-        }
-      )
-
-      it('Find with relations depth 0', function() {
-        const query = queryWithRelationDepth(0)
-
         return Promise.resolve()
-          .then(() => ParentTable.findById(parent.objectId, query))
-          .then(result => {
-            expect(result).to.have.property('child').that.have.to.be.null
-          })
-      })
-
-      it('Find with relations depth 1', function() {
-        const query = queryWithRelationDepth(1)
-
-        return Promise.resolve()
-          .then(() => ParentTable.findById(parent.objectId, query))
-          .then(result => {
-            expect(result).to.have.property('child').that.have.to.be.not.null
-            expect(result.child).to.have.property('grandChild').that.have.to.be.null
-          })
-      })
-
-      it('Find with relations depth 2', function() {
-        const query = queryWithRelationDepth(2)
-
-        return Promise.resolve()
-          .then(() => ParentTable.findById(parent.objectId, query))
-          .then(result => {
-            expect(result).to.have.property('child').that.have.to.be.not.null
-            expect(result.child).to.have.property('grandChild').that.have.to.be.not.null
-          })
-      })
-    })
-
-    it('Find first/last on empty table', function() {
-      const db = Persistence.of('EmptyTable')
-
-      return Promise.resolve()
-        .then(() => db.findFirst())
-        .catch(error => {
-          expect(error.code).to.be.equal(1009)
-        })
-    })
-
-    it('Find with offset greater than the max number of records', function() {
-      const db = Persistence.of('TableWithPagination')
-      const query = Backendless.DataQueryBuilder.create().setOffset(500)
-
-      return Promise.resolve()
-        .then(createBigTable)
-        .then(() => db.find(query))
-        .then(result => {
-          expect(result).to.be.an('Array')
-          expect(result.length).to.be.equal(0)
-        })
-    })
-
-    it('Retrieves Properties of table', function() {
-      return Promise.resolve()
-        .then(() => insertRecord('Blackstar', { integerCol: 1, boolCol: false }))
-        .then(() => Persistence.describe('Blackstar'))
-        .then(schema => {
-          schema.forEach(schemaObject => expect(schemaObject).to.have.all.keys([
-            'name', 'required', 'type', 'defaultValue', 'relatedTable', 'customRegex', 'autoLoad', 'isPrimaryKey'
-          ]))
-        })
-    })
-
-    it('Retrieves Properties of non existing table', function() {
-      return expect(Persistence.describe('NonExistingTable'))
-        .to.eventually.be.rejected
-        .and.eventually.to.have.property('code', 1009)
-    })
-
-    it('Sort by', function() {
-      const db = Persistence.of('TableWithPagination')
-      const query = Backendless.DataQueryBuilder.create().setSortBy('counter').setPageSize(100)
-
-      return Promise.resolve()
-        .then(createBigTable)
-        .then(() => db.find(query))
-        .then(result => {
-          expect(result).to.have.lengthOf(100)
-          result.forEach((record, idx) => {
-            expect(result[idx]).to.have.property('counter').that.equal(idx)
-          })
-        })
-    })
-
-    it('Retrieve object count', function() {
-      const db = Persistence.of('TableWithPagination')
-      const whereClause = Backendless.DataQueryBuilder.create().setWhereClause('counter < 50')
-
-      return Promise.resolve()
-        .then(createBigTable)
-        .then(() => db.getObjectCount())
-        .then(count => expect(count).to.be.equal(101))
-        .then(() => db.getObjectCount(whereClause))
-        .then(count => expect(count).to.be.equal(50))
-    })
-
-    it('Retrieving nextPage', function() {
-      const db = Persistence.of('TableWithPagination')
-      const query = Backendless.DataQueryBuilder.create().setSortBy('counter')
-
-      return Promise.resolve()
-        .then(createBigTable)
-        .then(() => db.find(query))
-        .then(result => {
-          expect(result).to.have.lengthOf(10)
-          expect(result[9]).to.have.property('counter').that.equal(9)
-        })
-        .then(() => query.prepareNextPage())
-        .then(() => db.find(query))
-        .then(result => {
-          expect(result).to.have.lengthOf(10)
-          expect(result[9]).to.have.property('counter').that.equal(19)
-        })
-    })
-
-    it('Set relations', function() {
-      const joeThePlumber = {
-        name    : 'Joe',
-        age     : 27,
-        phone   : '1-972-5551212',
-        title   : 'Plumber',
-        ___class: 'Contact'
+          .then(() => save('Parent').then(result => parent = result))
+          .then(() => save('Child').then(result => child = result))
+          .then(() => save('GrandChild').then(result => grandchild = result))
+          .then(() => ParentTable.addRelation(parent.objectId, 'child:Child:1', [child]))
+          .then(() => ChildTable.addRelation(child.objectId, 'grandChild:GrandChild:1', [grandchild]))
       }
+    )
 
-      const address = {
-        street  : '123 Main St.',
-        city    : 'Denver',
-        state   : 'Colorado',
-        ___class: 'Address'
-      }
+    it('Find with relations depth 0', function() {
+      const query = queryWithRelationDepth(0)
 
-      const contactStore = Persistence.of('Contact')
-      const addressStore = Persistence.of('Address')
-
-      Promise.all([
-        contactStore.save(joeThePlumber),
-        addressStore.save(address)
-      ])
-        .then(([savedContact, savedAddress]) => {
-          return contactStore.setRelation(savedContact, 'address:Address', [savedAddress])
-        })
+      return Promise.resolve()
+        .then(() => ParentTable.findById(parent.objectId, query))
         .then(result => {
-          console.log(result)
+          expect(result).to.have.property('child').that.have.to.be.null
         })
     })
+
+    it('Find with relations depth 1', function() {
+      const query = queryWithRelationDepth(1)
+
+      return Promise.resolve()
+        .then(() => ParentTable.findById(parent.objectId, query))
+        .then(result => {
+          expect(result).to.have.property('child').that.have.to.be.not.null
+          expect(result.child).to.have.property('grandChild').that.have.to.be.null
+        })
+    })
+
+    it('Find with relations depth 2', function() {
+      const query = queryWithRelationDepth(2)
+
+      return Promise.resolve()
+        .then(() => ParentTable.findById(parent.objectId, query))
+        .then(result => {
+          expect(result).to.have.property('child').that.have.to.be.not.null
+          expect(result.child).to.have.property('grandChild').that.have.to.be.not.null
+        })
+    })
+  })
+
+  it('Find first/last on empty table', function() {
+    const db = Persistence.of('EmptyTable')
+
+    return Promise.resolve()
+      .then(() => db.findFirst())
+      .catch(error => {
+        expect(error.code).to.be.equal(1009)
+      })
+  })
+
+  it('Find with offset greater than the max number of records', function() {
+    const db = Persistence.of('TableWithPagination')
+    const query = Backendless.DataQueryBuilder.create().setOffset(500)
+
+    return Promise.resolve()
+      .then(createBigTable)
+      .then(() => db.find(query))
+      .then(result => {
+        expect(result).to.be.an('Array')
+        expect(result.length).to.be.equal(0)
+      })
+  })
+
+  it('Retrieves Properties of table', function() {
+    return Promise.resolve()
+      .then(() => insertRecord('Blackstar', { integerCol: 1, boolCol: false }))
+      .then(() => Persistence.describe('Blackstar'))
+      .then(schema => {
+        schema.forEach(schemaObject => expect(schemaObject).to.have.all.keys([
+          'name', 'required', 'type', 'defaultValue', 'relatedTable', 'customRegex', 'autoLoad', 'isPrimaryKey'
+        ]))
+      })
+  })
+
+  it('Retrieves Properties of non existing table', function() {
+    return expect(Persistence.describe('NonExistingTable'))
+      .to.eventually.be.rejected
+      .and.eventually.to.have.property('code', 1009)
+  })
+
+  it('Sort by', function() {
+    const db = Persistence.of('TableWithPagination')
+    const query = Backendless.DataQueryBuilder.create().setSortBy('counter').setPageSize(100)
+
+    return Promise.resolve()
+      .then(createBigTable)
+      .then(() => db.find(query))
+      .then(result => {
+        expect(result).to.have.lengthOf(100)
+        result.forEach((record, idx) => {
+          expect(result[idx]).to.have.property('counter').that.equal(idx)
+        })
+      })
+  })
+
+  it('Retrieve object count', function() {
+    const db = Persistence.of('TableWithPagination')
+    const whereClause = Backendless.DataQueryBuilder.create().setWhereClause('counter < 50')
+
+    return Promise.resolve()
+      .then(createBigTable)
+      .then(() => db.getObjectCount())
+      .then(count => expect(count).to.be.equal(101))
+      .then(() => db.getObjectCount(whereClause))
+      .then(count => expect(count).to.be.equal(50))
+  })
+
+  it('Retrieving nextPage', function() {
+    const db = Persistence.of('TableWithPagination')
+    const query = Backendless.DataQueryBuilder.create().setSortBy('counter')
+
+    return Promise.resolve()
+      .then(createBigTable)
+      .then(() => db.find(query))
+      .then(result => {
+        expect(result).to.have.lengthOf(10)
+        expect(result[9]).to.have.property('counter').that.equal(9)
+      })
+      .then(() => query.prepareNextPage())
+      .then(() => db.find(query))
+      .then(result => {
+        expect(result).to.have.lengthOf(10)
+        expect(result[9]).to.have.property('counter').that.equal(19)
+      })
+  })
+
+  it('Set relations', function() {
+    const joeThePlumber = {
+      name    : 'Joe',
+      age     : 27,
+      phone   : '1-972-5551212',
+      title   : 'Plumber',
+      ___class: 'Contact'
+    }
+
+    const address = {
+      street  : '123 Main St.',
+      city    : 'Denver',
+      state   : 'Colorado',
+      ___class: 'Address'
+    }
+
+    const contactStore = Persistence.of('Contact')
+    const addressStore = Persistence.of('Address')
+
+    Promise.all([
+      contactStore.save(joeThePlumber),
+      addressStore.save(address)
+    ])
+      .then(([savedContact, savedAddress]) => {
+        return contactStore.setRelation(savedContact, 'address:Address', [savedAddress])
+      })
+      .then(result => {
+        console.log(result)
+      })
   })
 
   /****************
@@ -638,4 +641,6 @@ describe('Backendless.Persistence', function() {
     })
   })
 })
+
+
 

--- a/test/e2e/specs/persistence.js
+++ b/test/e2e/specs/persistence.js
@@ -317,22 +317,29 @@ describe('Backendless.Persistence', function() {
     })
 
     it('Find First', function() {
-      const db = Persistence.of('TableWithPagination')
+      const db = Persistence.of('TestFindFirst')
 
       return Promise.resolve()
-        .then(createBigTable)
+        .then(() => insertRecord('TestFindFirst', { counter: 0, name: 'First' }))
+        .then(() => insertRecord('TestFindFirst', { counter: 1, name: 'Last' }))
         .then(() => db.findFirst())
-        .then(result => expect(result.name).to.be.equal('Initial'))
+        .then(result => {
+          expect(result.counter).to.be.equal(0)
+          expect(result.name).to.be.equal('First')
+        })
     })
 
     it('Find Last', function() {
-      const db = Persistence.of('TableWithPagination')
-      const query = Backendless.DataQueryBuilder.create().setSortBy('counter')
+      const db = Persistence.of('TestFindLast')
 
       return Promise.resolve()
-        .then(createBigTable)
-        .then(() => db.findLast(query))
-        .then(result => expect(result.counter).to.be.equal(100))
+        .then(() => insertRecord('TestFindLast', { counter: 0, name: 'First' }))
+        .then(() => insertRecord('TestFindLast', { counter: 1, name: 'Last' }))
+        .then(() => db.findLast())
+        .then(result => {
+          expect(result.counter).to.be.equal(1)
+          expect(result.name).to.be.equal('Last')
+        })
     })
 
     it('Find first/last on empty table', function() {


### PR DESCRIPTION
Add ability to use query object in `findById`, `findFirst` and `findLast` methods
Remove redundant old helper for building data query object.