### PR TITLE
Add new methods `addRelation` and `setRelations` to LoadRelationsQueryBuilder

### DIFF
--- a/src/backendless.d.ts
+++ b/src/backendless.d.ts
@@ -143,6 +143,7 @@ declare module __Backendless {
 
         addProperty(prop:string):void;
         setOption(name:string, value:string|Array<string>|number):void;
+        addOption(name:string, value:string|Array<string>|number):void;
         setOptions(options:Object):void;
         getOption(name:string):string|Array<string>|number;
         toJSON():Object;
@@ -203,6 +204,8 @@ declare module __Backendless {
         setRelationName(relationName:string):Backendless.LoadRelationsQueryBuilder;
         setPageSize(pageSize:number):Backendless.LoadRelationsQueryBuilder;
         setOffset(offset:number):Backendless.LoadRelationsQueryBuilder;
+        addRelation(relation:string):Backendless.LoadRelationsQueryBuilder;
+        setRelations(relation:Array<string>):Backendless.LoadRelationsQueryBuilder;
         prepareNextPage():Backendless.LoadRelationsQueryBuilder;
         preparePreviousPage():Backendless.LoadRelationsQueryBuilder;
         build():Backendless.DataQueryValueI;

--- a/src/backendless.js
+++ b/src/backendless.js
@@ -5330,6 +5330,14 @@
       this.options[name] = value;
     },
 
+    addOption: function(name, value) {
+      this.options = this.options || {};
+      var option = this.options[name] || [];
+      this.options[name] = Utils.isArray(option) ? option : Utils.castArray(option);
+
+      this.options[name].push(value);
+    },
+
     setOptions: function(options) {
       for (var key in options) {
         if (options.hasOwnProperty(key)) {
@@ -5502,7 +5510,10 @@
   };
 
   LoadRelationsQueryBuilder.prototype = {
+    /** @deprecated */
     setRelationName: function(relationName) {
+      console.warn('Calling deprecated method!');
+
       this._query.setOption('relationName', relationName);
       return this;
     },
@@ -5525,6 +5536,18 @@
 
     preparePreviousPage: function() {
       this._paging.preparePreviousPage();
+
+      return this;
+    },
+
+    addRelation: function(relation) {
+      this._query.addOption('relations', relation);
+
+      return this;
+    },
+
+    setRelations: function(relations) {
+      this._query.setOption('relations', relations);
 
       return this;
     },


### PR DESCRIPTION
Mark `setRelationName` method as deprecated.