### PR TITLE
Fix: registerDevice method considered as synchronous when using with just one argument (other's are optional)

### DIFF
--- a/src/messaging/methods/register-device.js
+++ b/src/messaging/methods/register-device.js
@@ -2,15 +2,11 @@ import Utils from '../../utils'
 import Urls from '../../urls'
 import Device from '../../device'
 import Request from '../../request'
-import Async from '../../request/async'
 
 export function registerDevice(deviceToken, channels, expiration, asyncHandler) {
   const device = Device.required()
 
-  if (expiration instanceof Async) {
-    asyncHandler = expiration
-    expiration = undefined
-  }
+  asyncHandler = Utils.extractResponder(arguments)
 
   const data = {
     deviceToken: deviceToken,


### PR DESCRIPTION
#BKNDLSS-19288