### PR TITLE
Add `mapTableToClass` method to create custom mapping between data tables and client classes

### DIFF
--- a/backendless.d.ts
+++ b/backendless.d.ts
@@ -512,8 +512,9 @@ declare module __Backendless {
         model: Function | Object;
         className: string;
         restUrl: string;
+        classToTableMap: Object;
 
-        constructor(name: string | Object | Function);
+        constructor(name: string | Object | Function, classToTableMap: Object);
 
         save(obj: Object): Promise<Object>;
         save<T>(obj: T): Promise<T>;
@@ -622,6 +623,8 @@ declare module __Backendless {
         callStoredProcedure(spName: string, argumentValues: Object | string): Promise<Object>;
 
         callStoredProcedureSync(spName: string, argumentValues: Object | string): Object;
+
+        mapTableToClass(tableName: string, clientClass: Function);
     }
 
     /**

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -34,8 +34,12 @@ const Data = {
   },
 
   mapTableToClass(tableName, clientClass) {
+    if (!tableName) {
+      throw new Error('Table name is not specified')
+    }
+
     if (!clientClass) {
-      throw new Error('Class is not defined')
+      throw new Error('Class is not specified')
     }
 
     classToTableMap[tableName] = clientClass

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -8,13 +8,15 @@ import LoadRelationsQueryBuilder from './load-relations-query-builder'
 
 import { describe } from './describe'
 
+const classToTableMap = {}
+
 const Data = {
   Permissions              : Permissions,
   QueryBuilder             : QueryBuilder,
   LoadRelationsQueryBuilder: LoadRelationsQueryBuilder,
 
   of: function(model) {
-    return new Store(model)
+    return new Store(model, classToTableMap)
   },
 
   @deprecated('Backendless.Data', 'Backendless.Data.describe')
@@ -29,8 +31,15 @@ const Data = {
   @deprecated('Backendless.Data', 'Backendless.Data.of(<ClassName>).save')
   saveSync(className, obj, asyncHandler){
     return this.of(className).saveSync(obj, asyncHandler)
-  }
+  },
 
+  mapTableToClass(tableName, clientClass) {
+    if (!clientClass) {
+      throw new Error('Class is not defined')
+    }
+
+    classToTableMap[tableName] = clientClass
+  }
 }
 
 export default Data

--- a/src/data/store/find.js
+++ b/src/data/store/find.js
@@ -11,7 +11,7 @@ import { extractQueryOptions } from './extract-query-options'
 
 //TODO: refactor me
 
-export function findUtil(className, Model, dataQuery, asyncHandler) {
+export function findUtil(className, Model, dataQuery, asyncHandler, classToTableMap) {
   dataQuery = dataQuery || {}
 
   const dataQueryURL = dataQuery.url
@@ -23,7 +23,7 @@ export function findUtil(className, Model, dataQuery, asyncHandler) {
   const query = []
 
   if (asyncHandler) {
-    asyncHandler = Utils.wrapAsync(asyncHandler, resp => parseFindResponse(resp, Model))
+    asyncHandler = Utils.wrapAsync(asyncHandler, resp => parseFindResponse(resp, Model, classToTableMap))
   }
 
   if (dataQuery.options) {
@@ -63,7 +63,7 @@ export function findUtil(className, Model, dataQuery, asyncHandler) {
     return result
   }
 
-  return parseFindResponse(result, Model)
+  return parseFindResponse(result, Model, classToTableMap)
 }
 
 export function find(queryBuilder, asyncHandler) {
@@ -78,7 +78,7 @@ export function find(queryBuilder, asyncHandler) {
     throw new Error('The first argument should be instance of Backendless.DataQueryBuilder')
   }
 
-  return findUtil(this.className, this.model, queryBuilder, asyncHandler)
+  return findUtil(this.className, this.model, queryBuilder, asyncHandler, this.classToTableMap)
 }
 
 export function findById() {
@@ -93,7 +93,7 @@ export function findById() {
       throw new Error('missing argument "object ID" for method findById()')
     }
 
-    return findUtil(this.className, this.model, argsObj, responder)
+    return findUtil(this.className, this.model, argsObj, responder, this.classToTableMap)
   } else if (Utils.isObject(arguments[0])) {
     argsObj = arguments[0]
     const url = Urls.dataTable(this.className)
@@ -137,7 +137,7 @@ export function findFirst(dataQuery, asyncHandler) {
 
   dataQuery.url = 'first'
 
-  return findUtil(this.className, this.model, dataQuery, asyncHandler)
+  return findUtil(this.className, this.model, dataQuery, asyncHandler, this.classToTableMap)
 }
 
 export function findLast(dataQuery, asyncHandler) {
@@ -148,5 +148,5 @@ export function findLast(dataQuery, asyncHandler) {
 
   dataQuery.url = 'last'
 
-  return findUtil(this.className, this.model, dataQuery, asyncHandler)
+  return findUtil(this.className, this.model, dataQuery, asyncHandler, this.classToTableMap)
 }

--- a/src/data/store/index.js
+++ b/src/data/store/index.js
@@ -15,14 +15,16 @@ const namespaceLabel = 'Backendless.Data.of(<ClassName>)'
 
 class DataStore {
 
-  constructor(model) {
+  constructor(model, classToTableMap) {
+    this.classToTableMap = classToTableMap
+
     if (Utils.isString(model)) {
       this.className = model
-      this.model = resolveModelClassFromString(this.className)
+      this.model = classToTableMap[this.className] || resolveModelClassFromString(this.className)
 
     } else {
       this.className = Utils.getClassName(model)
-      this.model = model
+      this.model = classToTableMap[this.className] || model
     }
 
     if (!this.className) {

--- a/src/data/store/parse.js
+++ b/src/data/store/parse.js
@@ -64,11 +64,11 @@ function parseCircularDependencies(obj) {
   return result
 }
 
-export function parseFindResponse(response, Model) {
+export function parseFindResponse(response, Model, classToTableMap) {
   const sanitizeResponseItem = resp => {
     Model = Utils.isFunction(Model) ? Model : resolveModelClassFromString(resp.___class)
 
-    return Utils.deepExtend(new Model(), resp.fields || resp)
+    return Utils.deepExtend(new Model(), resp.fields || resp, classToTableMap)
   }
 
   const result = Utils.isArray(response)

--- a/src/data/store/save.js
+++ b/src/data/store/save.js
@@ -60,5 +60,5 @@ export function save(obj, asyncHandler) {
     return result
   }
 
-  return Utils.deepExtend(objRef, parseFindResponse(result, this.model))
+  return Utils.deepExtend(objRef, parseFindResponse(result, this.model), this.classToTableMap)
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -97,12 +97,12 @@ const Utils = {
     return arr.map(item => encodeURIComponent(item)).join(',')
   },
 
-  deepExtend(destination, source) {
+  deepExtend(destination, source, classToTableMap = {}) {
     //TODO: refactor it
     for (const property in source) {
       if (source[property] !== undefined && source.hasOwnProperty(property)) {
         destination[property] = destination[property] || {}
-        destination[property] = classWrapper(source[property])
+        destination[property] = classWrapper(source[property], classToTableMap)
 
         if (
           destination[property]
@@ -111,7 +111,7 @@ const Utils = {
           && destination[property][property].hasOwnProperty('__originSubID')
         ) {
 
-          destination[property][property] = classWrapper(destination[property])
+          destination[property][property] = classWrapper(destination[property], classToTableMap)
         }
       }
     }
@@ -210,7 +210,7 @@ function isBrowser() {
   return (typeof self === 'object' && self.self === self) && (typeof window === 'object' && window === self)
 }
 
-function classWrapper(obj) {
+function classWrapper(obj, classToTableMap) {
   //TODO: refactor it
   const wrapper = obj => {
     let wrapperName = null
@@ -227,8 +227,8 @@ function classWrapper(obj) {
 
     if (wrapperName) {
       try {
-        Wrapper = eval(wrapperName)
-        obj = Utils.deepExtend(new Wrapper(), obj)
+        Wrapper = classToTableMap[wrapperName] || eval(wrapperName)
+        obj = Utils.deepExtend(new Wrapper(), obj, classToTableMap)
       } catch (e) {
       }
     }


### PR DESCRIPTION
**Usage:**
```js
class PlaceToEat {
  constructor(props = {}) {
    let { name, ownerId, objectId, cuisine, updated, created, location, owner } = props

    this.objectId = objectId
    this.name = name
    this.ownerId = ownerId
    this.cuisine = cuisine
    this.updated = updated
    this.created = created
    this.owner = owner
    this.location = location
  }

  // skipping getters and setters for brevity
}

class Information {
  constructor(props = {}) {
    const { streetAddress, country, objectId, updated, created, ownerId, city, phoneNumber, menu } = props

    this.objectId = objectId
    this.streetAddress = streetAddress
    this.country = country
    this.updated = updated
    this.created = created
    this.ownerId = ownerId
    this.city = city
    this.phoneNumber = phoneNumber
    this.menu = menu
  }

  // skipping getters and setters for brevity
}

Backendless.Data.mapTableToClass('Restaurant', PlaceToEat)
Backendless.Data.mapTableToClass('Location', Information)

const query = Backendless.DataQueryBuilder.create()
  .addRelated('location')

Backendless.Data.of('Restaurant').find(query)
```

**Results:**
```
[ PlaceToEat {
    objectId: '55070490-CE2D-6C7E-FF97-99CF012E5700',
    name: 'Beef & Wine',
    ownerId: '0D9F870F-666E-FDE1-FF84-7731F3498200',
    cuisine: undefined,
    updated: 1569919487240,
    created: 1569919463225,
    owner: undefined,
    location:
     Information {
       objectId: '3086C565-DCC9-949D-FF55-CAD1E02BF200',
       streetAddress: undefined,
       country: undefined,
       updated: null,
       created: 1569919527652,
       ownerId: null,
       city: undefined,
       phoneNumber: undefined,
       menu: undefined,
       ___class: 'Location' },
    ___class: 'Restaurant' } ]
```