### PR TITLE
- improve method Files.upload 

### DIFF
--- a/src/files/index.js
+++ b/src/files/index.js
@@ -49,9 +49,18 @@ export default class Files {
 
     filePath = FilesUtils.preventSlashInPath(filePath)
 
+    const pathTokens = FilesUtils.parseFilePath(filePath)
+
+    let fileName
+
+    if (pathTokens.fileName) {
+      filePath = pathTokens.filePath
+      fileName = pathTokens.fileName
+    }
+
     if (typeof file === 'string') {
       return this.app.request.post({
-        url  : `${this.app.urls.filePath(filePath)}`,
+        url  : `${this.app.urls.filePath(filePath)}/${fileName}`,
         query: query,
         data : {
           url: file
@@ -59,7 +68,9 @@ export default class Files {
       })
     }
 
-    let fileName = FilesUtils.getFileName(file)
+    if (!fileName) {
+      fileName = FilesUtils.getFileName(file)
+    }
 
     if (!fileName) {
       throw new Error('Wrong type of the file source object. Can not get file name')

--- a/src/files/utils.js
+++ b/src/files/utils.js
@@ -4,7 +4,25 @@ const FilesUtils = {
   },
 
   preventSlashInPath(path) {
-    return (path && path.startsWith('/')) ? path.replace('/', '') : path
+    return (path && path.startsWith('/')) ? path.slice(1) : path
+  },
+
+  parseFilePath(path) {
+    const result = {
+      filePath: path,
+      fileName: null,
+    }
+
+    if (path) {
+      const tokens = path.split('/')
+
+      if (tokens[tokens.length - 1].includes('.')) {
+        result.fileName = tokens.pop()
+        result.filePath = tokens.join('/')
+      }
+    }
+
+    return result
   },
 
   sanitizeFileName(fileName) {

--- a/test/unit/specs/files/browser.js
+++ b/test/unit/specs/files/browser.js
@@ -95,7 +95,7 @@ describe('<Files> Browser', function() {
 
   describe('Upload', () => {
 
-    it('uploads a file', async () => {
+    it('uploads a file instance of File with name', async () => {
       const req1 = prepareMockRequest({ resultFileURL })
       const req2 = prepareMockRequest({ resultFileURL })
 
@@ -121,6 +121,90 @@ describe('<Files> Browser', function() {
 
       expect(req2.body).to.be.instanceof(FormData)
       expect(req2.body.get('file')).to.be.equal(file)
+    })
+
+    it('uploads a file instance of File without name', async () => {
+      const req1 = prepareMockRequest({ resultFileURL })
+      const req2 = prepareMockRequest({ resultFileURL })
+
+      const file = new File(Buffer.from('test-content'), null)
+
+      await Backendless.Files.upload(file, `${filePath}/test-name.txt`)
+      await Backendless.Files.upload(file, `${filePathWithSlash}/test-name.txt`)
+
+      expect(req1).to.deep.include({
+        method : 'POST',
+        path   : `${APP_PATH}/files/test/path/test-name.txt`,
+        headers: {},
+      })
+
+      expect(req2).to.deep.include({
+        method : 'POST',
+        path   : `${APP_PATH}/files/test/path/test-name.txt`,
+        headers: {},
+      })
+
+      expect(req1.body).to.be.instanceof(FormData)
+      expect(req1.body.get('file')).to.be.equal(file)
+
+      expect(req2.body).to.be.instanceof(FormData)
+      expect(req2.body.get('file')).to.be.equal(file)
+    })
+
+    it('uploads a file instance of File and name in path', async () => {
+      const req1 = prepareMockRequest({ resultFileURL })
+      const req2 = prepareMockRequest({ resultFileURL })
+
+      const file = new File(Buffer.from('test-content'), 'file.jpg')
+
+      await Backendless.Files.upload(file, `${filePath}/test-name.txt`)
+      await Backendless.Files.upload(file, `${filePathWithSlash}/test-name.txt`)
+
+      expect(req1).to.deep.include({
+        method : 'POST',
+        path   : `${APP_PATH}/files/test/path/test-name.txt`,
+        headers: {},
+      })
+
+      expect(req2).to.deep.include({
+        method : 'POST',
+        path   : `${APP_PATH}/files/test/path/test-name.txt`,
+        headers: {},
+      })
+
+      expect(req1.body).to.be.instanceof(FormData)
+      expect(req1.body.get('file')).to.be.equal(file)
+
+      expect(req2.body).to.be.instanceof(FormData)
+      expect(req2.body.get('file')).to.be.equal(file)
+    })
+
+    it('uploads a file instance of Blob without name', async () => {
+      const req1 = prepareMockRequest({ resultFileURL })
+      const req2 = prepareMockRequest({ resultFileURL })
+
+      const file = new Blob(Buffer.from('test-content'), { type: 'test-type' })
+
+      await Backendless.Files.upload(file, `${filePath}/test-name.txt`)
+      await Backendless.Files.upload(file, `${filePathWithSlash}/test-name.txt`)
+
+      expect(req1).to.deep.include({
+        method : 'POST',
+        path   : `${APP_PATH}/files/test/path/test-name.txt`,
+        headers: {},
+      })
+
+      expect(req2).to.deep.include({
+        method : 'POST',
+        path   : `${APP_PATH}/files/test/path/test-name.txt`,
+        headers: {},
+      })
+
+      expect(req1.body).to.be.instanceof(FormData)
+      expect(req1.body.get('file').type).to.be.equal('test-type')
+
+      expect(req2.body).to.be.instanceof(FormData)
+      expect(req2.body.get('file').type).to.be.equal('test-type')
     })
 
     it('uploads a file with path', async () => {

--- a/test/unit/specs/files/nodejs.js
+++ b/test/unit/specs/files/nodejs.js
@@ -17,7 +17,7 @@ describe('<Files> Nodejs', function() {
 
   describe('Upload', () => {
 
-    it('uploads a file', async () => {
+    it('uploads a file instance of ReadStream with name', async () => {
       const req1 = prepareMockRequest({ resultFileURL })
 
       const fileStream = fs.createReadStream(sourceFilePath)
@@ -27,6 +27,23 @@ describe('<Files> Nodejs', function() {
       expect(req1).to.deep.include({
         method : 'POST',
         path   : `${APP_PATH}/files/test/path/${currentFileName}`,
+        headers: {},
+      })
+
+      // getBoundary is a method of FormData (nodejs) instance
+      expect(req1.body.getBoundary()).to.be.a('string')
+    })
+
+    it('uploads a file instance of ReadStream with name in path', async () => {
+      const req1 = prepareMockRequest({ resultFileURL })
+
+      const fileStream = fs.createReadStream(sourceFilePath)
+
+      await Backendless.Files.upload(fileStream, `${targetDirPath}/foo.png`)
+
+      expect(req1).to.deep.include({
+        method : 'POST',
+        path   : `${APP_PATH}/files/test/path/foo.png`,
         headers: {},
       })
 


### PR DESCRIPTION
- improve method Files.upload to upload a file with filename in the passed path argument

for example:

```
const file = new Blob(Buffer.from('test-content'))

await Backendless.Files.upload(file, `my-directory/for/uploading/test-file-name.txt`)
```