### PR TITLE
- add API for getting a list of all the Atomic Counters

### DIFF
--- a/backendless.d.ts
+++ b/backendless.d.ts
@@ -543,6 +543,8 @@ declare module Backendless {
      * @namespace Backendless.Counters
      **/
     namespace Counters {
+        function list(pattern?: string): Promise<string[]>;
+
         function of(counterName: string): Counter;
 
         function get(counterName: string): Promise<number>;

--- a/src/counters/index.js
+++ b/src/counters/index.js
@@ -9,6 +9,16 @@ export default class Counters {
     return new Counter(name, this)
   }
 
+  async list(pattern) {
+    if (pattern !== null && pattern !== undefined && typeof pattern !== 'string') {
+      throw new Error('Counters Pattern can be a string only')
+    }
+
+    return this.app.request.get({
+      url: this.app.urls.countersList(pattern),
+    })
+  }
+
   async incrementAndGet(counterName) {
     if (!counterName || typeof counterName !== 'string') {
       throw new Error('Counter Name must be provided and must be a string.')

--- a/src/urls.js
+++ b/src/urls.js
@@ -55,6 +55,10 @@ export default class Urls {
     return `${this.root()}/counters`
   }
 
+  countersList(pattern) {
+    return `${this.counters()}/${pattern || '*'}/list`
+  }
+
   counter(name) {
     return `${this.counters()}/${name}`
   }

--- a/test/e2e/specs/counters.js
+++ b/test/e2e/specs/counters.js
@@ -88,6 +88,29 @@ describe('Backendless.Counters', function() {
     })
   })
 
+  describe('list', function() {
+
+    beforeEach(async () => {
+      await Backendless.Counters.incrementAndGet('testPattern1')
+      await Backendless.Counters.incrementAndGet('testPattern2bar')
+      await Backendless.Counters.incrementAndGet('testPattern3bar')
+    })
+
+    it('gets a list without pattern', async () => {
+      const list = await Backendless.Counters.list()
+
+      expect(list).to.include.members(['testPattern1', 'testPattern2bar', 'testPattern3bar'])
+    })
+
+    it('gets a list with pattern', async () => {
+      const list = await Backendless.Counters.list('testPattern*bar')
+
+      expect(list).to.not.include.members(['testPattern1'])
+      expect(list).to.include.members(['testPattern2bar', 'testPattern3bar'])
+    })
+
+  })
+
   describe('instance', function() {
 
     it('feature accessible', function() {

--- a/test/tsd.ts
+++ b/test/tsd.ts
@@ -1154,9 +1154,13 @@ function testCounters() {
     const expected: number = 123;
     const updated: number = 123;
     let promiseObject: Promise<Object>;
+    let promiseStrings: Promise<string[]>;
 
     //'implementMethod', 'get', 'implementMethodWithValue', 'compareAndSet'
     let resultNum: number = 123;
+
+    promiseStrings = Backendless.Counters.list();
+    promiseStrings = Backendless.Counters.list('*');
 
     promiseObject = Backendless.Counters.get(counterName);
 

--- a/test/unit/specs/counters.js
+++ b/test/unit/specs/counters.js
@@ -265,6 +265,51 @@ describe('<Counters>', function() {
     })
   })
 
+  describe('list', () => {
+
+    it('gets a list without pattern', async () => {
+      const req1 = prepareMockRequest(['foo', 'bar', 'test1'])
+
+      const result = await Backendless.Counters.list()
+
+      expect(req1).to.deep.include({
+        method : 'GET',
+        path   : `${APP_PATH}/counters/*/list`,
+        headers: {},
+        body   : undefined
+      })
+
+      expect(result).to.be.eql(['foo', 'bar', 'test1'])
+    })
+
+    it('gets a list with pattern', async () => {
+      const req1 = prepareMockRequest(['test1', 'test2', 'test3'])
+
+      const result = await Backendless.Counters.list('test*')
+
+      expect(req1).to.deep.include({
+        method : 'GET',
+        path   : `${APP_PATH}/counters/test*/list`,
+        headers: {},
+        body   : undefined
+      })
+
+      expect(result).to.be.eql(['test1', 'test2', 'test3'])
+    })
+
+    it('fails when passed expected/updated to compareAndSet are not numbers', async () => {
+      const expectedValueErrorMsg = 'Counters Pattern can be a string only'
+
+      await expect(Backendless.Counters.list(true)).to.eventually.be.rejectedWith(expectedValueErrorMsg)
+      await expect(Backendless.Counters.list(false)).to.eventually.be.rejectedWith(expectedValueErrorMsg)
+      await expect(Backendless.Counters.list(0)).to.eventually.be.rejectedWith(expectedValueErrorMsg)
+      await expect(Backendless.Counters.list(123)).to.eventually.be.rejectedWith(expectedValueErrorMsg)
+      await expect(Backendless.Counters.list({})).to.eventually.be.rejectedWith(expectedValueErrorMsg)
+      await expect(Backendless.Counters.list([])).to.eventually.be.rejectedWith(expectedValueErrorMsg)
+      await expect(Backendless.Counters.list(() => ({}))).to.eventually.be.rejectedWith(expectedValueErrorMsg)
+    })
+  })
+
   describe('instance', () => {
 
     const counter = Backendless.Counters.of(counterName)


### PR DESCRIPTION
```
  Backendless.Counters.list(pattern?: string): Promise<string[]>;
```